### PR TITLE
refactor: replace inline styles with CSS modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,33 +21,13 @@
     <meta name="twitter:title" content="moliseke — Clear. Secure. Fast." />
     <meta name="twitter:description" content="On-prem → Azure/AWS migrations, email to Microsoft 365 & Google Workspace, and Terraform deployments for SMBs." />
     <meta name="twitter:image" content="og.png" />
-
-    <!-- Base styles -->
-    <style>
-      :root{--midnight:#0E1B2E;--brand:#2A6AF4;--teal:#00796B;--neutral:#475569;--cloud:#F5F7FA;--white:#FFFFFF}
-      html,body,#root{height:100%}
-      body{margin:0;background:var(--cloud);color:var(--neutral);font-family:Inter,system-ui,Arial,sans-serif}
-      .container{max-width:1120px;margin:0 auto;padding:0 24px}
-      .btn{display:inline-flex;gap:8px;align-items:center;padding:12px 18px;border-radius:14px;font-weight:700;text-decoration:none}
-      .btn-primary{background:var(--brand);color:#fff}
-      .btn-outline{border:1px solid rgba(255,255,255,.35);color:#fff}
-      .card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06)}
-      .chip{display:inline-block;border:1px solid #e5e7eb;background:#fff;border-radius:999px;padding:8px 14px;font-size:14px}
-      header.sticky{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.7);border-bottom:1px solid #e5e7eb;z-index:40}
-      nav a{color:var(--neutral);text-decoration:none;margin-left:18px}
-      nav a:hover{text-decoration:underline}
-      h1,h2,h3{font-family:Manrope,Inter,Arial,sans-serif}
-      .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-      .grid{display:grid;gap:16px}
-      @media (min-width:900px){ .grid-3{grid-template-columns:1fr 1fr 1fr} .grid-5{grid-template-columns:repeat(5,1fr)} }
-    </style>
+    <link rel="stylesheet" href="/src/global.css" />
   </head>
 
   <body>
     <div id="root"></div>
 
     <noscript>
-      <style>body{font-family:system-ui,Arial,sans-serif;padding:24px}</style>
       <h1>moliseke</h1>
       <p>Enable JavaScript to view this site.</p>
     </noscript>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,116 @@
 import React from 'react'
 import Header, { BrandIcon } from './components/Header'
-const C={midnight:'#0E1B2E',brand:'#2A6AF4',teal:'#00796B',neutral:'#475569',cloud:'#F5F7FA',white:'#FFFFFF'}
-function Icon({name,size=20,color=C.brand}){const p={fill:'none',stroke:color,strokeWidth:2,strokeLinecap:'round',strokeLinejoin:'round'}; if(name==='cloud')return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='M20 17.5a3.5 3.5 0 0 0-3.5-3.5h-.5a5 5 0 0 0-9.7-1.5A3 3 0 0 0 6 19h10.5A3.5 3.5 0 0 0 20 17.5z'/></svg>); if(name==='mail')return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='M4 6h16v12H4z'/><path {...p} d='m22 6-10 7L2 6'/></svg>); if(name==='server')return(<svg width={size} height={size} viewBox='0 0 24 24'><rect {...p} x='3' y='4' width='18' height='6' rx='2'/><rect {...p} x='3' y='14' width='18' height='6' rx='2'/><path {...p} d='M7 8h.01M7 18h.01'/></svg>); if(name==='stack')return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='m12 2 9 5-9 5-9-5 9-5z'/><path {...p} d='m3 12 9 5 9-5'/><path {...p} d='m3 17 9 5 9-5'/></svg>); return null}
-export default function App(){return(<div style={{background:C.cloud,color:C.neutral}}>
- <Header />
-<section><div className='container' style={{padding:'64px 24px'}}><div style={{background:C.midnight,color:'#fff',borderRadius:24,padding:'40px 32px',position:'relative',boxShadow:'0 24px 40px rgba(2,6,23,.2)'}}><h1 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontSize:48,lineHeight:1.1,fontWeight:800}}>Cloud migrations & email moves for SMBs</h1><p style={{marginTop:12,opacity:.92,maxWidth:740}}>On-prem → Azure & AWS • Microsoft 365 / Google Workspace • Terraform deployments. We work across the US, Canada, UK, EU & Australia.</p><div style={{marginTop:18,display:'flex',gap:12,flexWrap:'wrap'}}><a href='#services' className='btn btn-primary'>Our services</a><a href='#contact' className='btn btn-outline'>Get in touch</a></div><div aria-hidden style={{position:'absolute',right:24,bottom:-24,opacity:.08,transform:'scale(2)'}}><BrandIcon size={120} stroke={8} color='#fff'/></div></div></div></section>
-<section id='services' style={{padding:'48px 0'}}><div className='container'><h2 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontWeight:800,color:C.midnight}}>Services</h2><div style={{display:'grid',gridTemplateColumns:'1fr',gap:16,marginTop:12}}><div className='card'><div style={{display:'flex',alignItems:'center',gap:10}}><Icon name='cloud'/><h3>On-prem → Azure & AWS migrations</h3></div><ul><li>• Discovery & readiness assessment</li><li>• Architecture & landing zone setup</li><li>• Cutover with rollback plan</li><li>• Security & compliance baked-in</li></ul></div><div className='card'><div style={{display:'flex',alignItems:'center',gap:10}}><Icon name='stack'/><h3>Email to Microsoft 365 & Google Workspace</h3></div><ul><li>• Domain & DNS alignment</li><li>• Mailbox & data migration (staged/cutover)</li><li>• Security policies: MFA, DKIM, DMARC</li><li>• End-user enablement & support</li></ul></div><div className='card'><div style={{display:'flex',alignItems:'center',gap:10}}><Icon name='server'/><h3>Infrastructure deployments with Terraform</h3></div><ul><li>• IaC standards for Azure & AWS</li><li>• CI/CD pipelines & environments</li><li>• Observability & cost guardrails</li><li>• Documentation & handover</li></ul></div></div></div></section>
-<section id='why' style={{padding:'48px 0',background:'#fff'}}><div className='container'><h2 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontWeight:800,color:C.midnight}}>Why moliseke</h2><div style={{display:'grid',gridTemplateColumns:'1fr 1fr 1fr',gap:12,marginTop:12}}><div className='card'><strong>Clarity over complexity</strong><p style={{marginTop:6}}>Readable runbooks, diagrams and status. We make cloud changes transparent.</p></div><div className='card'><strong>Security by design</strong><p style={{marginTop:6}}>MFA, least privilege and audit baked-in from day one—no surprises later.</p></div><div className='card'><strong>Measurable outcomes</strong><p style={{marginTop:6}}>Cutover windows, rollback points and KPI dashboards to prove value.</p></div></div></div></section>
-<section id='approach' style={{padding:'48px 0'}}><div className='container'><h2 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontWeight:800,color:C.midnight}}>Our approach</h2><div style={{display:'grid',gridTemplateColumns:'repeat(5,1fr)',gap:12,marginTop:12}}>{[{step:'Discover',desc:'Inventory, risks, success criteria'},{step:'Plan',desc:'Architecture, timeline, runbook'},{step:'Migrate',desc:'Pilot, iterate, cutover'},{step:'Harden',desc:'Security, backups, DR'},{step:'Operate',desc:'Docs, handover, support'}].map((s,i)=>(<div key={s.step} className='card'><div style={{color:C.teal,fontWeight:700,fontSize:12}}>{String(i+1).padStart(2,'0')}</div><div style={{fontWeight:700}}>{s.step}</div><div style={{fontSize:14,opacity:.8}}>{s.desc}</div></div>))}</div></div></section>
-<section id='regions' style={{padding:'48px 0'}}><div className='container'><h2 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontWeight:800,color:C.midnight}}>Regions we serve</h2><div style={{display:'flex',flexWrap:'wrap',gap:10,marginTop:10}}>{['United States','Canada','United Kingdom','European Union','Australia'].map(r=><span key={r} className='chip'>{r}</span>)}</div></div></section>
-<section id='contact' style={{padding:'48px 0',background:C.midnight,color:'#fff'}}><div className='container'><h2 style={{fontFamily:'Manrope,Inter,Arial,sans-serif',fontWeight:800}}>Let’s talk about your migration</h2><p style={{opacity:.9,maxWidth:720}}>Email us a short note about your current environment and target platform. We’ll reply with a brief plan and timeline options.</p><div style={{marginTop:12,display:'flex',gap:12,flexWrap:'wrap'}}><a href='mailto:info@moliseke.com' className='btn btn-primary'>info@moliseke.com</a><a href='#services' className='btn btn-outline'>Explore services</a></div></div></section>
-<footer style={{padding:'16px 0',background:'#fff',borderTop:'1px solid #e5e7eb'}}><div className='container' style={{display:'flex',alignItems:'center',justifyContent:'space-between',fontSize:14}}><div style={{display:'flex',alignItems:'center',gap:8}}><BrandIcon size={18}/><span>moliseke</span></div><div style={{opacity:.7}}>© {new Date().getFullYear()} moliseke — moliseke.com</div></div></footer>
-</div>)}
+import styles from './App.module.css'
+
+const C={midnight:'#0E1B2E',brand:'#2A6AF4',teal:'#00796B'}
+
+function Icon({name,size=20,color=C.brand}){
+  const p={fill:'none',stroke:color,strokeWidth:2,strokeLinecap:'round',strokeLinejoin:'round'}
+  if(name==='cloud')
+    return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='M20 17.5a3.5 3.5 0 0 0-3.5-3.5h-.5a5 5 0 0 0-9.7-1.5A3 3 0 0 0 6 19h10.5A3.5 3.5 0 0 0 20 17.5z'/></svg>)
+  if(name==='mail')
+    return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='M4 6h16v12H4z'/><path {...p} d='m22 6-10 7L2 6'/></svg>)
+  if(name==='server')
+    return(<svg width={size} height={size} viewBox='0 0 24 24'><rect {...p} x='3' y='4' width='18' height='6' rx='2'/><rect {...p} x='3' y='14' width='18' height='6' rx='2'/><path {...p} d='M7 8h.01M7 18h.01'/></svg>)
+  if(name==='stack')
+    return(<svg width={size} height={size} viewBox='0 0 24 24'><path {...p} d='m12 2 9 5-9 5-9-5 9-5z'/><path {...p} d='m3 12 9 5 9-5'/><path {...p} d='m3 17 9 5 9-5'/></svg>)
+  return null
+}
+
+export default function App(){
+  return(
+    <div className={styles.app}>
+      <Header />
+
+      <section>
+        <div className={`container ${styles.heroContainer}`}>
+          <div className={styles.hero}>
+            <h1 className={styles.heroTitle}>Cloud migrations & email moves for SMBs</h1>
+            <p className={styles.heroText}>On-prem → Azure & AWS • Microsoft 365 / Google Workspace • Terraform deployments. We work across the US, Canada, UK, EU & Australia.</p>
+            <div className={styles.heroActions}>
+              <a href='#services' className='btn btn-primary'>Our services</a>
+              <a href='#contact' className='btn btn-outline'>Get in touch</a>
+            </div>
+            <div aria-hidden className={styles.heroBrandIcon}>
+              <BrandIcon size={120} stroke={8} color='#fff'/>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id='services' className={styles.sectionPad}>
+        <div className='container'>
+          <h2 className={styles.sectionHeading}>Services</h2>
+          <div className={`grid grid-3 ${styles.servicesGrid}`}>
+            <div className='card'>
+              <div className={styles.cardHeader}><Icon name='cloud'/><h3>On-prem → Azure & AWS migrations</h3></div>
+              <ul><li>• Discovery & readiness assessment</li><li>• Architecture & landing zone setup</li><li>• Cutover with rollback plan</li><li>• Security & compliance baked-in</li></ul>
+            </div>
+            <div className='card'>
+              <div className={styles.cardHeader}><Icon name='stack'/><h3>Email to Microsoft 365 & Google Workspace</h3></div>
+              <ul><li>• Domain & DNS alignment</li><li>• Mailbox & data migration (staged/cutover)</li><li>• Security policies: MFA, DKIM, DMARC</li><li>• End-user enablement & support</li></ul>
+            </div>
+            <div className='card'>
+              <div className={styles.cardHeader}><Icon name='server'/><h3>Infrastructure deployments with Terraform</h3></div>
+              <ul><li>• IaC standards for Azure & AWS</li><li>• CI/CD pipelines & environments</li><li>• Observability & cost guardrails</li><li>• Documentation & handover</li></ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id='why' className={`${styles.sectionPad} ${styles.whySection}`}>
+        <div className='container'>
+          <h2 className={styles.sectionHeading}>Why moliseke</h2>
+          <div className={styles.whyGrid}>
+            <div className='card'><strong>Clarity over complexity</strong><p className={styles.whyCardText}>Readable runbooks, diagrams and status. We make cloud changes transparent.</p></div>
+            <div className='card'><strong>Security by design</strong><p className={styles.whyCardText}>MFA, least privilege and audit baked-in from day one—no surprises later.</p></div>
+            <div className='card'><strong>Measurable outcomes</strong><p className={styles.whyCardText}>Cutover windows, rollback points and KPI dashboards to prove value.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <section id='approach' className={styles.sectionPad}>
+        <div className='container'>
+          <h2 className={styles.sectionHeading}>Our approach</h2>
+          <div className={styles.approachGrid}>
+            {[{step:'Discover',desc:'Inventory, risks, success criteria'},{step:'Plan',desc:'Architecture, timeline, runbook'},{step:'Migrate',desc:'Pilot, iterate, cutover'},{step:'Harden',desc:'Security, backups, DR'},{step:'Operate',desc:'Docs, handover, support'}].map((s,i)=>(
+              <div key={s.step} className='card'>
+                <div className={styles.approachStep}>{String(i+1).padStart(2,'0')}</div>
+                <div className={styles.approachTitle}>{s.step}</div>
+                <div className={styles.approachDesc}>{s.desc}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id='regions' className={styles.sectionPad}>
+        <div className='container'>
+          <h2 className={styles.sectionHeading}>Regions we serve</h2>
+          <div className={styles.regionsGrid}>
+            {['United States','Canada','United Kingdom','European Union','Australia'].map(r=><span key={r} className='chip'>{r}</span>)}
+          </div>
+        </div>
+      </section>
+
+      <section id='contact' className={`${styles.sectionPad} ${styles.contactSection}`}>
+        <div className='container'>
+          <h2 className={styles.sectionHeadingLight}>Let’s talk about your migration</h2>
+          <p className={styles.contactText}>Email us a short note about your current environment and target platform. We’ll reply with a brief plan and timeline options.</p>
+          <div className={styles.contactActions}>
+            <a href='mailto:info@moliseke.com' className='btn btn-primary'>info@moliseke.com</a>
+            <a href='#services' className='btn btn-outline'>Explore services</a>
+          </div>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <div className={`container ${styles.footerInner}`}>
+          <div className={styles.footerBrand}><BrandIcon size={18}/><span>moliseke</span></div>
+          <div className={styles.footerCopy}>© {new Date().getFullYear()} moliseke — moliseke.com</div>
+        </div>
+      </footer>
+
+    </div>
+  )
+}

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,27 @@
+.app{background:var(--cloud);color:var(--neutral)}
+.heroContainer{padding:64px 24px}
+.hero{background:var(--midnight);color:#fff;border-radius:24px;padding:40px 32px;position:relative;box-shadow:0 24px 40px rgba(2,6,23,.2)}
+.heroTitle{font-family:Manrope,Inter,Arial,sans-serif;font-size:48px;line-height:1.1;font-weight:800}
+.heroText{margin-top:12px;opacity:.92;max-width:740px}
+.heroActions{margin-top:18px;display:flex;gap:12px;flex-wrap:wrap}
+.heroBrandIcon{position:absolute;right:24px;bottom:-24px;opacity:.08;transform:scale(2)}
+.sectionPad{padding:48px 0}
+.sectionHeading{font-family:Manrope,Inter,Arial,sans-serif;font-weight:800;color:var(--midnight)}
+.sectionHeadingLight{font-family:Manrope,Inter,Arial,sans-serif;font-weight:800}
+.servicesGrid{margin-top:12px}
+.cardHeader{display:flex;align-items:center;gap:10px}
+.whySection{background:#fff}
+.whyGrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;margin-top:12px}
+.whyCardText{margin-top:6px}
+.approachGrid{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-top:12px}
+.approachStep{color:var(--teal);font-weight:700;font-size:12px}
+.approachTitle{font-weight:700}
+.approachDesc{font-size:14px;opacity:.8}
+.regionsGrid{display:flex;flex-wrap:wrap;gap:10px;margin-top:10px}
+.contactSection{background:var(--midnight);color:#fff}
+.contactText{opacity:.9;max-width:720px}
+.contactActions{margin-top:12px;display:flex;gap:12px;flex-wrap:wrap}
+.footer{padding:16px 0;background:#fff;border-top:1px solid #e5e7eb}
+.footerInner{display:flex;align-items:center;justify-content:space-between;font-size:14px}
+.footerBrand{display:flex;align-items:center;gap:8px}
+.footerCopy{opacity:.7}

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,16 @@
+:root{--midnight:#0E1B2E;--brand:#2A6AF4;--teal:#00796B;--neutral:#475569;--cloud:#F5F7FA;--white:#FFFFFF}
+html,body,#root{height:100%}
+body{margin:0;background:var(--cloud);color:var(--neutral);font-family:Inter,system-ui,Arial,sans-serif}
+.container{max-width:1120px;margin:0 auto;padding:0 24px}
+.btn{display:inline-flex;gap:8px;align-items:center;padding:12px 18px;border-radius:14px;font-weight:700;text-decoration:none}
+.btn-primary{background:var(--brand);color:#fff}
+.btn-outline{border:1px solid rgba(255,255,255,.35);color:#fff}
+.card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06)}
+.chip{display:inline-block;border:1px solid #e5e7eb;background:#fff;border-radius:999px;padding:8px 14px;font-size:14px}
+header.sticky{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.7);border-bottom:1px solid #e5e7eb;z-index:40}
+nav a{color:var(--neutral);text-decoration:none;margin-left:18px}
+nav a:hover{text-decoration:underline}
+h1,h2,h3{font-family:Manrope,Inter,Arial,sans-serif}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.grid{display:grid;gap:16px}
+@media (min-width:900px){.grid-3{grid-template-columns:1fr 1fr 1fr}.grid-5{grid-template-columns:repeat(5,1fr)}}


### PR DESCRIPTION
## Summary
- move global styles to `global.css` and load via link
- convert `App.jsx` inline styles into `App.module.css` classes
- remove in-document style tags in `index.html`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c041571888832f8a0a2737dfb5cb3b