### PR TITLE
Add hover and scroll animations for service cards

### DIFF
--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styles from '../App.module.css';
 
 const C = { midnight: '#0E1B2E', brand: '#2A6AF4', teal: '#00796B' };
@@ -38,12 +38,31 @@ function Icon({ name, size = 20, color = C.brand }) {
 }
 
 export default function Services() {
+  const cardsRef = useRef([]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.3 }
+    );
+
+    cardsRef.current.forEach((card) => card && observer.observe(card));
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <section id='services' className={styles.sectionPad}>
       <div className='container'>
         <h2 className={styles.sectionHeading}>Services</h2>
         <div className={`grid grid-3 ${styles.servicesGrid}`}>
-          <div className='card'>
+          <div className='card' ref={(el) => (cardsRef.current[0] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='cloud' />
               <h3>On-prem → Azure & AWS migrations</h3>
@@ -55,7 +74,7 @@ export default function Services() {
               <li>• Security & compliance baked-in</li>
             </ul>
           </div>
-          <div className='card'>
+          <div className='card' ref={(el) => (cardsRef.current[1] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='stack' />
               <h3>Email to Microsoft 365 & Google Workspace</h3>
@@ -67,7 +86,7 @@ export default function Services() {
               <li>• End-user enablement & support</li>
             </ul>
           </div>
-          <div className='card'>
+          <div className='card' ref={(el) => (cardsRef.current[2] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='server' />
               <h3>Infrastructure deployments with Terraform</h3>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -62,7 +62,7 @@ export default function Services() {
       <div className='container'>
         <h2 className={styles.sectionHeading}>Services</h2>
         <div className={`grid grid-3 ${styles.servicesGrid}`}>
-          <div className='card' ref={(el) => (cardsRef.current[0] = el)}>
+          <div className='card service-card' ref={(el) => (cardsRef.current[0] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='cloud' />
               <h3>On-prem → Azure & AWS migrations</h3>
@@ -74,7 +74,7 @@ export default function Services() {
               <li>• Security & compliance baked-in</li>
             </ul>
           </div>
-          <div className='card' ref={(el) => (cardsRef.current[1] = el)}>
+          <div className='card service-card' ref={(el) => (cardsRef.current[1] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='stack' />
               <h3>Email to Microsoft 365 & Google Workspace</h3>
@@ -86,7 +86,7 @@ export default function Services() {
               <li>• End-user enablement & support</li>
             </ul>
           </div>
-          <div className='card' ref={(el) => (cardsRef.current[2] = el)}>
+          <div className='card service-card' ref={(el) => (cardsRef.current[2] = el)}>
             <div className={styles.cardHeader}>
               <Icon name='server' />
               <h3>Infrastructure deployments with Terraform</h3>

--- a/src/global.css
+++ b/src/global.css
@@ -5,7 +5,9 @@ body{margin:0;background:var(--cloud);color:var(--neutral);font-family:Inter,sys
 .btn{display:inline-flex;gap:8px;align-items:center;padding:12px 18px;border-radius:14px;font-weight:700;text-decoration:none}
 .btn-primary{background:var(--brand);color:#fff}
 .btn-outline{border:1px solid rgba(255,255,255,.35);color:#fff}
-.card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06)}
+.card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06);transition:transform .4s cubic-bezier(.4,0,.2,1),opacity .4s cubic-bezier(.4,0,.2,1);opacity:0;transform:translateY(20px)}
+.card.visible{opacity:1;transform:translateY(0)}
+.card:hover{transform:translateY(-5px) scale(1.03);transition:transform .2s cubic-bezier(.4,0,.2,1)}
 .chip{display:inline-block;border:1px solid #e5e7eb;background:#fff;border-radius:999px;padding:8px 14px;font-size:14px}
 header.sticky{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.7);border-bottom:1px solid #e5e7eb;z-index:40}
 nav a{color:var(--neutral);text-decoration:none;margin-left:18px}

--- a/src/global.css
+++ b/src/global.css
@@ -5,9 +5,10 @@ body{margin:0;background:var(--cloud);color:var(--neutral);font-family:Inter,sys
 .btn{display:inline-flex;gap:8px;align-items:center;padding:12px 18px;border-radius:14px;font-weight:700;text-decoration:none}
 .btn-primary{background:var(--brand);color:#fff}
 .btn-outline{border:1px solid rgba(255,255,255,.35);color:#fff}
-.card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06);transition:transform .4s cubic-bezier(.4,0,.2,1),opacity .4s cubic-bezier(.4,0,.2,1);opacity:0;transform:translateY(20px)}
-.card.visible{opacity:1;transform:translateY(0)}
-.card:hover{transform:translateY(-5px) scale(1.03);transition:transform .2s cubic-bezier(.4,0,.2,1)}
+.card{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:20px;box-shadow:0 8px 24px rgba(2,6,23,.06)}
+.service-card{transition:transform .4s cubic-bezier(.4,0,.2,1),opacity .4s cubic-bezier(.4,0,.2,1);opacity:0;transform:translateY(20px)}
+.service-card.visible{opacity:1;transform:translateY(0)}
+.service-card:hover{transform:translateY(-5px) scale(1.03);transition:transform .2s cubic-bezier(.4,0,.2,1)}
 .chip{display:inline-block;border:1px solid #e5e7eb;background:#fff;border-radius:999px;padding:8px 14px;font-size:14px}
 header.sticky{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.7);border-bottom:1px solid #e5e7eb;z-index:40}
 nav a{color:var(--neutral);text-decoration:none;margin-left:18px}


### PR DESCRIPTION
## Summary
- animate service cards on scroll and hover using CSS transitions
- add IntersectionObserver to reveal cards when in view

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0485433e0832f8a5333df76f58b28