### PR TITLE
Display region flags and platform logos

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -19,6 +19,7 @@
 .approachDesc{font-size:14px;opacity:.8}
 .regionsGrid{display:flex;flex-wrap:wrap;gap:10px;margin-top:10px}
 .flagChip{display:flex;align-items:center;gap:6px}
+.logoItem{display:flex;align-items:center;gap:6px}
 .logosGrid{display:flex;flex-wrap:wrap;gap:20px;align-items:center;margin-top:20px}
 .logosGrid img{height:32px}
 .contactSection{background:var(--midnight);color:#fff}

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -18,6 +18,9 @@
 .approachTitle{font-weight:700}
 .approachDesc{font-size:14px;opacity:.8}
 .regionsGrid{display:flex;flex-wrap:wrap;gap:10px;margin-top:10px}
+.flagChip{display:flex;align-items:center;gap:6px}
+.logosGrid{display:flex;flex-wrap:wrap;gap:20px;align-items:center;margin-top:20px}
+.logosGrid img{height:32px}
 .contactSection{background:var(--midnight);color:#fff}
 .contactText{opacity:.9;max-width:720px}
 .contactActions{margin-top:12px;display:flex;gap:12px;flex-wrap:wrap}

--- a/src/components/Regions.jsx
+++ b/src/components/Regions.jsx
@@ -1,16 +1,43 @@
 import React from 'react';
 import styles from '../App.module.css';
 
+const regions = [
+  { name: 'United States', code: 'us' },
+  { name: 'Canada', code: 'ca' },
+  { name: 'United Kingdom', code: 'uk' },
+  { name: 'European Union', code: 'eu' },
+  { name: 'Australia', code: 'au' },
+];
+
+const logos = [
+  { name: 'Microsoft 365', file: '365' },
+  { name: 'AWS', file: 'aws' },
+  { name: 'Azure', file: 'azure' },
+  { name: 'Elasticsearch', file: 'elasticsearch' },
+  { name: 'GitHub', file: 'github' },
+  { name: 'GitLab', file: 'gitlab' },
+  { name: 'SharePoint', file: 'sharepoint' },
+  { name: 'Slack', file: 'slack' },
+  { name: 'Teams', file: 'teams' },
+  { name: 'Windows', file: 'windows' },
+];
+
 export default function Regions() {
   return (
     <section id='regions' className={styles.sectionPad}>
       <div className='container'>
         <h2 className={styles.sectionHeading}>Regions we serve</h2>
         <div className={styles.regionsGrid}>
-          {['United States', 'Canada', 'United Kingdom', 'European Union', 'Australia'].map(r => (
-            <span key={r} className='chip'>
-              {r}
+          {regions.map(({ name, code }) => (
+            <span key={name} className={`chip ${styles.flagChip}`}>
+              <img src={`/flags/${code}.svg`} alt='' width='20' height='20' />
+              {name}
             </span>
+          ))}
+        </div>
+        <div className={styles.logosGrid}>
+          {logos.map(({ name, file }) => (
+            <img key={file} src={`/logos/${file}.svg`} alt={`${name} logo`} loading='lazy' />
           ))}
         </div>
       </div>

--- a/src/components/Regions.jsx
+++ b/src/components/Regions.jsx
@@ -9,19 +9,6 @@ const regions = [
   { name: 'Australia', code: 'au' },
 ];
 
-const logos = [
-  { name: 'Microsoft 365', file: '365' },
-  { name: 'AWS', file: 'aws' },
-  { name: 'Azure', file: 'azure' },
-  { name: 'Elasticsearch', file: 'elasticsearch' },
-  { name: 'GitHub', file: 'github' },
-  { name: 'GitLab', file: 'gitlab' },
-  { name: 'SharePoint', file: 'sharepoint' },
-  { name: 'Slack', file: 'slack' },
-  { name: 'Teams', file: 'teams' },
-  { name: 'Windows', file: 'windows' },
-];
-
 export default function Regions() {
   return (
     <section id='regions' className={styles.sectionPad}>
@@ -33,11 +20,6 @@ export default function Regions() {
               <img src={`/flags/${code}.svg`} alt='' width='20' height='20' />
               {name}
             </span>
-          ))}
-        </div>
-        <div className={styles.logosGrid}>
-          {logos.map(({ name, file }) => (
-            <img key={file} src={`/logos/${file}.svg`} alt={`${name} logo`} loading='lazy' />
           ))}
         </div>
       </div>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -114,12 +114,16 @@ export default function Services() {
         </div>
         <div className={styles.logosGrid}>
           {logos.map(({ name, file }) => (
-            <img
-              key={file}
-              src={`/logos/${file}.svg`}
-              alt={`${name} logo`}
-              loading='lazy'
-            />
+            <span key={file} className={styles.logoItem}>
+              <img
+                src={`/logos/${file}.svg`}
+                alt={`${name} logo`}
+                width='32'
+                height='32'
+                loading='lazy'
+              />
+              {name}
+            </span>
           ))}
         </div>
       </div>

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -3,6 +3,19 @@ import styles from '../App.module.css';
 
 const C = { midnight: '#0E1B2E', brand: '#2A6AF4', teal: '#00796B' };
 
+const logos = [
+  { name: 'Microsoft 365', file: '365' },
+  { name: 'AWS', file: 'aws' },
+  { name: 'Azure', file: 'azure' },
+  { name: 'Elasticsearch', file: 'elasticsearch' },
+  { name: 'GitHub', file: 'github' },
+  { name: 'GitLab', file: 'gitlab' },
+  { name: 'SharePoint', file: 'sharepoint' },
+  { name: 'Slack', file: 'slack' },
+  { name: 'Teams', file: 'teams' },
+  { name: 'Windows', file: 'windows' },
+];
+
 function Icon({ name, size = 20, color = C.brand }) {
   const p = { fill: 'none', stroke: color, strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round' };
   if (name === 'cloud')
@@ -98,6 +111,16 @@ export default function Services() {
               <li>• Documentation & handover</li>
             </ul>
           </div>
+        </div>
+        <div className={styles.logosGrid}>
+          {logos.map(({ name, file }) => (
+            <img
+              key={file}
+              src={`/logos/${file}.svg`}
+              alt={`${name} logo`}
+              loading='lazy'
+            />
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- show region flags alongside region chips
- list supported platform logos beneath regions
- add styles for flag chips and logos grid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2cf46cdec832f9e6d4ed57cff2d55